### PR TITLE
BUG: fix pointers and PlayerState implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(
     src/input/InputReceiver.cxx
     src/render/SpriteLoader.cxx
     src/render/Sprite.cxx
+    src/game/state/playerState/PlayerState.cxx
 )
 
 # sdl2 linking variables

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 # set the project name and version
-project(RLFight VERSION 0.7)
+project(RLFight VERSION 0.8)
 
 # specify the C++ standard
 set(CMAKE_CXX_STANDARD 11)

--- a/src/game/Game.cxx
+++ b/src/game/Game.cxx
@@ -3,6 +3,7 @@
 #include "game/Game.h"
 #include "render/Application.h"
 #include "input/InputReceiver.h"
+#include "game/state/playerState/PlayerState.h"
 
 
 struct Game::Impl {
@@ -17,6 +18,7 @@ struct Game::Impl {
         std::cout << "Game state initialised with initial player position: " << currentState.getPlayerLocation() << std::endl;
         currentFrame = 0;
         std::cout << "Initialised current frame to value: " << currentFrame << std::endl;
+        PlayerState ps((char*)"abc", false);
     }
 
     GameState step()

--- a/src/game/state/playerState/FireKnight.cxx
+++ b/src/game/state/playerState/FireKnight.cxx
@@ -1,0 +1,18 @@
+#include "game/state/playerState/FireKnight.h"
+
+FireKnightStates::FireKnightStates()
+:idle(PlayerState::PlayerState(
+    "idle",
+    // Animation(
+    //     ("1", "assets/fire-knight/idle/idle_1.png"),
+    //     ("2", "assets/fire-knight/idle/idle_2.png"),
+    //     ("3", "assets/fire-knight/idle/idle_3.png"),
+    //     ("4", "assets/fire-knight/idle/idle_4.png"),
+    //     ("5", "assets/fire-knight/idle/idle_5.png"),
+    //     ("6", "assets/fire-knight/idle/idle_6.png"),
+    //     ("7", "assets/fire-knight/idle/idle_7.png"),
+    //     ("8", "assets/fire-knight/idle/idle_8.png")
+    // ),
+    false
+)
+{ }

--- a/src/game/state/playerState/FireKnight.h
+++ b/src/game/state/playerState/FireKnight.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "game/state/playerState/PlayerState.h"
+
+enum struct FireKnightStates
+{
+    Idle
+};
+
+struct FireKnightStatesFinal
+{
+    PlayerState idle;
+};
+
+class FireKnightStates
+{
+public:
+    FireKnightStates();
+    ~FireKnightStates();
+
+    PlayerState *getIdleState();
+
+private:
+    PlayerState idle;
+};

--- a/src/game/state/playerState/PlayerState.cxx
+++ b/src/game/state/playerState/PlayerState.cxx
@@ -1,0 +1,18 @@
+#include <iostream>
+
+#include "SDL.h"
+
+#include "game/state/playerState/PlayerState.h"
+
+PlayerState::PlayerState(std::string name, bool isBlockingAction)
+: name(name)
+, isBlockingAction(isBlockingAction)
+{
+    SDL_Log("Player state created");
+    SDL_Log(name.c_str());
+}
+
+PlayerState::~PlayerState()
+{
+    SDL_Log("Player state GC");
+}

--- a/src/game/state/playerState/PlayerState.h
+++ b/src/game/state/playerState/PlayerState.h
@@ -1,0 +1,13 @@
+#pragma once
+
+class PlayerState
+{
+public:
+    PlayerState(std::string name, bool isBlockingAction);
+    ~PlayerState();
+
+private:
+    std::string name;
+    // Animation animation;
+    bool isBlockingAction;
+};

--- a/src/render/Application.cxx
+++ b/src/render/Application.cxx
@@ -1,12 +1,13 @@
 #include <iostream>
 
-#include "SDL.h"
+#include "SDL_image.h"
 
 #include "render/Application.h"
 
 Application::Application()
 {
     SDL_Init(SDL_INIT_VIDEO);
+    IMG_Init(IMG_INIT_PNG);
 
     window = SDL_CreateWindow(
         "RLFight",
@@ -19,10 +20,12 @@ Application::Application()
 
     renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_SOFTWARE);
     std::cout << "Leaving application initialiser" << std::endl;
-    SpriteLoader sl = SpriteLoader(renderer);
-    testSprite = sl.getSprite();
-    Sprite ssl = *testSprite;
-    ssl.render(renderer, 300, 300, 1.0);
+    // Application::
+
+    // SpriteLoader sl = SpriteLoader(renderer);
+    // testSprite = sl.getSprite();
+    // Sprite ssl = *testSprite;
+    // ssl.render(renderer, 300, 300, 1.0);
     // SDL_Quit();
 }
 
@@ -46,7 +49,7 @@ void Application::render(int xPosition)
     SDL_SetRenderDrawColor(renderer, 255, 255, 255, SDL_ALPHA_OPAQUE);
     SDL_RenderDrawRect(renderer, &rect);
 
-    testSprite->render(renderer, 300, 300, 1.0);
+    // testSprite->render(renderer, 300, 300, 1.0);
 
     SDL_SetRenderDrawColor(renderer, 0, 0, 0, SDL_ALPHA_OPAQUE);
     // std::cout << "Starting render presenting" << std::endl;
@@ -62,8 +65,10 @@ void Application::render(int xPosition)
 // teardown for when object leaves scope
 Application::~Application()
 {
-    SDL_DestroyTexture(testTexture);
+    SDL_Log("Application GC");
+    // SDL_DestroyTexture(testTexture);
     SDL_DestroyRenderer(renderer);
     SDL_DestroyWindow(window);
+    IMG_Quit();
     SDL_Quit();
 }

--- a/src/render/Application.h
+++ b/src/render/Application.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "SDL.h"
-#include "SpriteLoader.h"
+// #include "SpriteLoader.h"
 
 class Application
 {
@@ -16,7 +16,7 @@ private:
     SDL_Window *window;
     SDL_Renderer *renderer;
     Uint32 frameStartTime;
-    SpriteLoader *spriteLoader;
-    SDL_Texture *testTexture;
-    Sprite *testSprite;
+    // SpriteLoader *spriteLoader;
+    // SDL_Texture *testTexture;
+    // Sprite *testSprite;
 };


### PR DESCRIPTION
Removed use of `SpriteLoader.h` temporarily and replaced with a `PlayerState.h` class. Added a WIP player state implementation for the Fire Knight character. 