### PR TITLE
DOCS: fix build and publish directories

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -23,7 +23,7 @@ jobs:
           pip install -r doc/requirements.txt
       - name: Sphinx build
         run: |
-          sphinx-build -M html doc/source doc/build
+          sphinx-build -M html doc/source _build
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
Fixes the build directory of the `sphinx-build` command. This is needed for the github pages to render properly.