### PR TITLE
FIX: remove builder argument

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -23,7 +23,7 @@ jobs:
           pip install -r doc/requirements.txt
       - name: Sphinx build
         run: |
-          sphinx-build -M html doc/source _build
+          sphinx-build doc/source _build
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
Previously the builder argument (`-M`) was being passed to the sphinx build command. Removed it to generate docs as expected by the  github-pages deployment.